### PR TITLE
Add support for writing/reading Macros to and from EEPROM. Macros are…

### DIFF
--- a/MacroProcessor.cpp
+++ b/MacroProcessor.cpp
@@ -1,15 +1,24 @@
 #include "QueueArray.h"
 #include "MacroProcessor.h"
 #include "InputHandler.h"
+#include "EEPROM.h"
+#define MACRO_MAX_SIZE 128*6 + 1
+// Technically this may wear out the EEPROM but we need to define where they start and end.
+#define LARGEST_EEPROM_ADDRESS 2047
 
 MacroProcessor::MacroProcessor() 
 {
+  Serial.begin(9600); // For debugging
   m_EventQueue = new QueueArray<Event>();
   //TO DO: load macros from storage
+  readMacro(1);
+
 }
 
 MacroProcessor::~MacroProcessor()
 {
+  
+  writeMacro(1);
   while (!m_EventQueue->isEmpty())
     m_EventQueue->dequeue();
 
@@ -48,15 +57,69 @@ void MacroProcessor::DispatchEvent(Event& e)
     }
     if(e.Handled == true)   //For debugging
     {
-       Serial.print("sizeof(m_EventQueue)=");
-       Serial.println(sizeof(m_EventQueue));
-       Serial.print("Current Macro's Queue Size = ");
+       Serial.print("Number of events on eventqueue...");
        Serial.println(m_EventQueue->count());
        Serial.print("Handled event = ");
        Serial.println(e.code);
     }  
   } 
 }
+
+
+void MacroProcessor::writeMacro(uint8_t macroNumber) {
+    /* 
+    We need to write byte by byte to EEPROM
+    Also, we should store the last-written address so that we know where to write to next.
+    */
+    Event currentEvent;
+    uint16_t address; 
+    uint8_t eventSize = sizeof(Event);
+    address = MACRO_MAX_SIZE*(macroNumber-1);
+    Serial.println("Beginning write, initial address is:" + address);
+    uint8_t queueSize = m_EventQueue->count(); // We need to store this so we know how long each macro is.
+    EEPROM.update(address++, queueSize);
+    for (uint8_t i = 0; i < queueSize; i++) {  
+        Serial.println(address);
+        if (address >= LARGEST_EEPROM_ADDRESS) {
+            Serial.println("Tried to write to the largest possible address in EEPROM, and exiting loop...\n");
+            break;
+        }
+        currentEvent = m_EventQueue->dequeue();
+        EEPROM.put(address, currentEvent);
+        m_EventQueue->enqueue(currentEvent);
+        address += eventSize;
+    }
+
+
+}
+
+
+void MacroProcessor::readMacro(uint8_t macroNumber) {
+    uint16_t address = MACRO_MAX_SIZE*(macroNumber-1);
+    uint8_t queueSize = EEPROM.read(address++);
+    uint8_t eventSize = sizeof(Event);
+    Serial.println("Beginning read...");
+    for (uint8_t i = 0; i < queueSize; i++) {
+        Event e;
+        EEPROM.get(address, e);
+        
+        if (e.code < 0 || e.code > 20) {
+          // The above condition could be subject to change as we add more buttons
+          while (!m_EventQueue->isEmpty())
+            m_EventQueue->dequeue();
+          Serial.println("Event corrupted, emptied queue and exiting...");
+          break;
+        }
+        Serial.print("Current address: ");
+        Serial.println(address);
+        Serial.println(e.code);
+        m_EventQueue->enqueue(e);
+        address += eventSize;
+    }
+
+
+}
+
 
 void MacroProcessor::recordEvent(Event& e)
 {
@@ -66,13 +129,14 @@ void MacroProcessor::recordEvent(Event& e)
   { 
     m_State = State::IDLE;
     Serial.println("RECORDING STOPPED");  // For debugging
+    writeMacro(1);
+
   }
   else {
     unsigned long currentEventTime = millis();
     e.wait = currentEventTime - m_LastEventTime;
     m_LastEventTime = currentEventTime; // Set to the clocked currentEventTime
-    Serial.print("Enqueuing event = ");
-    Serial.println(e.code);
+
 
     m_EventQueue->enqueue(e);
   }
@@ -91,9 +155,11 @@ void MacroProcessor::startRecording()
 void MacroProcessor::executeMacro(uint8_t macro)
 {
   uint8_t size = m_EventQueue->count();   
+  Serial.print("Size of event queue in execution fxn ");
+  Serial.println(size);
+  
   for(uint8_t i = 0; i < size; i++) 
   {
-    
     Event e = m_EventQueue->dequeue();
     InputHandler::GetEventQueue().enqueue(e);
     m_EventQueue->enqueue(e);

--- a/MacroProcessor.h
+++ b/MacroProcessor.h
@@ -27,6 +27,9 @@ class MacroProcessor : public EventProcessor
     void executeMacro(uint8_t macro);
     void recordEvent(Event& e);
     void startRecording();
+    void readMacro(uint8_t macroNumber);
+    void writeMacro(uint8_t macroNumber);
+
     
   private:
     static constexpr uint8_t MAX_SIZE = 128;

--- a/accessible_controller_firmware.ino
+++ b/accessible_controller_firmware.ino
@@ -2,7 +2,7 @@
 #include "InputHandler.h"
 #include "MacroProcessor.h"
 #include "XInputAPI.h"
-
+#include "EEPROM.h"
 PlatformAPI* InitPlatformAPI()
 {
   switch(PlatformAPI::Current())


### PR DESCRIPTION
… read from EEPROM location 0 when the MacroProcessor constructor runs so these are now nonvolatile.